### PR TITLE
No colors on boot

### DIFF
--- a/Rainbowth.py
+++ b/Rainbowth.py
@@ -47,12 +47,14 @@ class Rainbowth(sublime_plugin.EventListener):
   # plugins are not loaded properly after a hot exit
   # this causes problems with files opened automatically at boot
   def on_activated(self, view):
-    file_scope = view.scope_name(0)
-    view.settings().set('lispy',
-        file_scope.split('.')[1].split(' ')[0] in ['lisp', 'scheme', 'clojure'])
-    if view.settings().get('lispy'):
-      self.update_colors(view)
-      self.on_modified(view, True)
+    if not view.settings().get('rainbowthed'):
+      file_scope = view.scope_name(0)
+      view.settings().set('lispy',
+          file_scope.split('.')[1].split(' ')[0] in ['lisp', 'scheme', 'clojure'])
+      if view.settings().get('lispy'):
+        self.update_colors(view)
+        self.on_modified(view, True)
+        view.settings().set('rainbowthed', True)
 
   def on_modified(self, view, load = False):
     if not view.settings().get('lispy'):

--- a/Rainbowth.py
+++ b/Rainbowth.py
@@ -44,7 +44,9 @@ class Rainbowth(sublime_plugin.EventListener):
     with open(cache_file_path, 'wb') as cache_file:
       pickle.dump(cache, cache_file)
 
-  def on_load(self, view):
+  # plugins are not loaded properly after a hot exit
+  # this causes problems with files opened automatically at boot
+  def on_activated(self, view):
     file_scope = view.scope_name(0)
     view.settings().set('lispy',
         file_scope.split('.')[1].split(' ')[0] in ['lisp', 'scheme', 'clojure'])


### PR DESCRIPTION
When after a hot exit, apparently the plugin goes through the `on_load` only once and not necessarily with a lispy view if some of the automatically opened files are not lispy. In that case the check is skipped and the colors are not assigned. Therefore the function has been switched from `on_load` to `on_activate` (whenever a view gets focus), but with a check added to go through it only once per view.
