### PR TITLE
Configure languages in settings

### DIFF
--- a/Rainbowth.sublime-settings
+++ b/Rainbowth.sublime-settings
@@ -1,4 +1,5 @@
 {
+  "languages": ["lisp", "scheme", "clojure", "clojurescript", "hylang"],
   "palettes":
   {
     "default": ["red", "orange", "yellow", "green", "blue", "indigo", "violet"],

--- a/rainbowth.py
+++ b/rainbowth.py
@@ -47,8 +47,6 @@ class ViewInfo:
                              scope=key, flags=sublime.DRAW_NO_OUTLINE)
 
 class Rainbowth(sublime_plugin.EventListener):
-    lispy_languages = ['lisp', 'scheme', 'clojure', 'clojurescript', 'hylang']
-
     @staticmethod
     def cache_file_path():
         result = os.path.join(sublime.cache_path(), 'Rainbowth', 'Rainbowth.cache')
@@ -183,7 +181,9 @@ class Rainbowth(sublime_plugin.EventListener):
         return False
 
     def on_activated_async(self, view):
-        view.settings().set('rainbowth.lispy', self.is_written_in(view, self.lispy_languages))
+        settings = sublime.load_settings('Rainbowth.sublime-settings')
+        languages = settings.get('languages')
+        view.settings().set('rainbowth.lispy', self.is_written_in(view, languages))
         if view.settings().get('rainbowth.lispy'):
             colors = self.update_color_scheme(view)
             view.settings().set('rainbowth.colors', colors)

--- a/rainbowth.py
+++ b/rainbowth.py
@@ -63,13 +63,13 @@ class Rainbowth(sublime_plugin.EventListener):
     def read_cache(self):
         if self.cache is None:
             if os.path.exists(self.cache_file_path()):
-                with open(self.cache_file_path(), 'r', 'utf-8') as cache_file:
+                with codecs.open(self.cache_file_path(), 'r', 'utf-8') as cache_file:
                     self.cache = json.load(cache_file)
             else:
                 self.cache = {}
 
     def write_cache(self):
-        with open(self.cache_file_path(), 'w', 'utf-8') as cache_file:
+        with codecs.open(self.cache_file_path(), 'w', 'utf-8') as cache_file:
             json.dump(self.cache, cache_file)
 
     def current_color_scheme(self, view):


### PR DESCRIPTION
Hello,
thank you for this plugin! 
I would like to have rainbow parentheses also for _non-lispy_ languages (such as `scala`) so I tried tweaking the `languages` list and it worked like a charm. Then I thought it would be handy to be able to configure the list of languages in settings and I came up with this pull request (please keep in mind that I know very little Python!).

Along the way I stumbled upon an error happening when reading/writing the cache file and fixed it, it's in the first commit.

Please let me know what you think about my changes!
