### PR TITLE
Highlight matching curly braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Rainbowth
 
 ### What is this?
 
-Rainbowth is a Sublime Text 3 plugin that automagically highlights matching parentheses in Lisp source code. While the name does imply a certain sequence of colors, the palette used to paint them is entirely configurable; nonetheless, the effect is perhaps best demonstrated when viewed with a theme like [Tomorrow Night](https://github.com/chriskempson/tomorrow-theme/tree/master/textmate):
+Rainbowth is a Sublime Text 3 plugin that automagically highlights matching parentheses, brackets, and curly braces in source code. While the name does imply a certain sequence of colors, the palette used to paint them is entirely configurable; nonetheless, the effect is perhaps best demonstrated when viewed with a theme like [Tomorrow Night](https://github.com/chriskempson/tomorrow-theme/tree/master/textmate):
 
 ![img](http://i.imgur.com/ja50Z.png)
 
@@ -19,7 +19,24 @@ The color scheme must be unpacked in the user's `Packages` folder and writable f
 
 ### Configuration
 
+Rainbowth's default configuration can be customized by creating a `Rainbowth.sublime-settings` file in `Packages/User`. 
+
 The `palettes` setting is a mapping of theme names to the list of colors to use for painting parentheses while using that theme, outermost first. When using a theme not specified, the default ROYGBIV sequence will be used.
+
+```
+{
+  "palettes": {
+    "default": ["red", "orange", "yellow", "green", "blue", "indigo", "violet"]
+  }
+}
+```
+
+Highlighting for a given language can be enabled (or disabled) by updating the `languages` setting.
+
+```
+{
+  "languages": ["lisp", "scheme", "clojure", "clojurescript", "hylang"]
+}```
 
 ### Contributing
 

--- a/rainbowth.py
+++ b/rainbowth.py
@@ -196,12 +196,12 @@ class Rainbowth(sublime_plugin.EventListener):
 
         level = -1
         per_line_depths = defaultdict(lambda: [[] for _ in range(len(colors))])
-        for region in view.find_all('[\[\]()]'):
+        for region in view.find_all('[\[\]()\{\}]'):
             char = view.substr(region)
             line, _ = view.rowcol(region.a)
-            if char in '([': level += 1
+            if char in '([{': level += 1
             per_line_depths[line][level % len(colors)].append(region)
-            if char in ')]': level -= 1
+            if char in ')]}': level -= 1
 
         self.view_infos[view.id()] = ViewInfo(len(colors), per_line_depths)
         view.settings().set('rainbowth.line', None)


### PR DESCRIPTION
Hi again,
I noticed that curly braces were not being highlighted and made a small change to address this (it's useful for languages like `clojure`, `scala`, and so on).
I also updated README to mention the recently-introduced `languages` setting.

If you are okay with these changes, could you possibly create a release?
