### PR TITLE
Added optional string exclusion and custom signs

### DIFF
--- a/Rainbowth.sublime-settings
+++ b/Rainbowth.sublime-settings
@@ -5,5 +5,7 @@
     "default": ["red", "orange", "yellow", "green", "blue", "indigo", "violet"],
     "Tomorrow Night": ["#c66", "#de935f", "#ee6", "#b5bd68", "#81a2be", "#b294bb", "#ff69b4", "#8a2be2"],
     "Monokai": ["#AE81FF", "#66D9EF", "#A6E22E", "#FD971F", "#F92672"]
-  }
+  },
+  //  Toggle whether strings should be ignored. Default: false
+  "disable_inside_string": false
 }

--- a/Rainbowth.sublime-settings
+++ b/Rainbowth.sublime-settings
@@ -7,5 +7,13 @@
     "Monokai": ["#AE81FF", "#66D9EF", "#A6E22E", "#FD971F", "#F92672"]
   },
   //  Toggle whether strings should be ignored. Default: false
-  "disable_inside_string": false
+  "disable_inside_string": false,
+  // Enables custom pre- and suffixes. Currently only single character 'fixes.
+  "custom_signs": 
+  {
+    "enabled": false,
+    // Note: Characters cannot appear in both the prefix and the suffix (Which only makes sense, doesn't it?)
+    "prefix": "({[",
+    "suffix": ")}]"
+  }    
 }

--- a/rainbowth.py
+++ b/rainbowth.py
@@ -194,9 +194,21 @@ class Rainbowth(sublime_plugin.EventListener):
             return
         colors = view.settings().get('rainbowth.colors')
 
+        settings = sublime.load_settings('Rainbowth.sublime-settings')
+        customRegex = settings.get('custom_regex')
+        if customRegex.enable:
+          regex = customRegex.prefix+customRegex.suffix
+          print(regex)
+        else:
+          disableString = settings.get('disable_inside_string')
+          if disableString: 
+            regex = '[()\[\]{}](?=([^"]*"[^"]*")*[^"]*$)'
+          else:
+            regex = '[\[\]()\{\}]'
+
         level = -1
         per_line_depths = defaultdict(lambda: [[] for _ in range(len(colors))])
-        for region in view.find_all('[\[\]()\{\}]'):
+        for region in view.find_all(regex):
             char = view.substr(region)
             line, _ = view.rowcol(region.a)
             if char in '([{': level += 1

--- a/rainbowth.py
+++ b/rainbowth.py
@@ -195,25 +195,32 @@ class Rainbowth(sublime_plugin.EventListener):
         colors = view.settings().get('rainbowth.colors')
 
         settings = sublime.load_settings('Rainbowth.sublime-settings')
-        customRegex = settings.get('custom_regex')
-        if customRegex.enable:
-          regex = customRegex.prefix+customRegex.suffix
+        customSigns = settings.get('custom_signs')
+        if customSigns['enabled']:
+          prefix = customSigns['prefix'] 
+          suffix = customSigns['suffix']
+          regex = prefix + suffix
           print(regex)
         else:
-          disableString = settings.get('disable_inside_string')
-          if disableString: 
-            regex = '[()\[\]{}](?=([^"]*"[^"]*")*[^"]*$)'
-          else:
-            regex = '[\[\]()\{\}]'
+          prefix = '(['
+          suffix = ')]'
+
+        disableString = settings.get('disable_inside_string')
+        if disableString: 
+          # regex = '[()\[\]{}](?=([^"\']*["\'][^"\']*["\'])*[^"\']*$)'
+          regex = '['+re.escape(prefix) + re.escape(suffix)+'](?=([^"\']*["\'][^"\']*["\'])*[^"\']*$)'
+        else:
+          # regex = '[\[\]\{\}()]'
+          regex = '['+re.escape(prefix) + re.escape(suffix)+']'
 
         level = -1
         per_line_depths = defaultdict(lambda: [[] for _ in range(len(colors))])
         for region in view.find_all(regex):
             char = view.substr(region)
             line, _ = view.rowcol(region.a)
-            if char in '([{': level += 1
+            if char in prefix: level += 1
             per_line_depths[line][level % len(colors)].append(region)
-            if char in ')]}': level -= 1
+            if char in suffix: level -= 1
 
         self.view_infos[view.id()] = ViewInfo(len(colors), per_line_depths)
         view.settings().set('rainbowth.line', None)


### PR DESCRIPTION
Added two optional settings: 

- `disable_inside_string` to exclude signs inside strings (i.e. inside either `"` or `'`)
![image](https://user-images.githubusercontent.com/7855659/33513597-572c8b96-d74e-11e7-9bdf-46a3891ae052.png)

- `custom_signs` to add/remove characters from the rainbow
 ![image](https://user-images.githubusercontent.com/7855659/33513581-08756fa4-d74e-11e7-8991-f274084da8a0.png)
![image](https://user-images.githubusercontent.com/7855659/33513571-e73f6b28-d74d-11e7-9a1d-e5edebb9f88d.png)
