### PR TITLE
Added disable_in_comment option, changed disabling.

### DIFF
--- a/Rainbowth.sublime-settings
+++ b/Rainbowth.sublime-settings
@@ -21,6 +21,9 @@
     // Toggle whether strings should be ignored. Default: false
     "disable_inside_string": false,
 
+    // Toggle whether comments should be ignored. Default: false
+    "disable_inside_comment": false,
+
     // Enables custom pre- and suffixes. Currently only single character 'fixes.
     // Note: Characters cannot appear in both the prefix and the suffix (Which only makes sense, doesn't it?)
     // Default prefix and suffix are just () and [].


### PR DESCRIPTION
PR to solve #37 

Changed the disable logic for strings and comments to use SublimeText's labeled regions rather than regex matching
I don't know how it affects performance, but it seems more clean/extensible this way.
Feedback welcome, this started as a hacky workaround for me.